### PR TITLE
Fix duplicating bug

### DIFF
--- a/source/scripts/calendar.js
+++ b/source/scripts/calendar.js
@@ -427,11 +427,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const extraButtons = document.getElementById('extraButtons');
         const [, date] = event.target.id.split('.');
 
-        // Clear previous buttons to prevent duplication
-        extraButtons.innerHTML = formatDate(date);
-
         // Fetch entries based on date
         const entries = await window.api.getEntriesOnDate(date);
+
+        // Clear previous buttons to prevent duplication
+        extraButtons.innerHTML = formatDate(date);
 
         // Create and append buttons
         entries.forEach((entry) => {


### PR DESCRIPTION
## Tracking Info

Resolves #101 

## Changes

<!-- What changes did you make? -->
Switched the order of  fetching the entries with `getEntriesOnDate` and clearing `extraButtons.innerHTML`, now on lines 431 and 434 of `calendar.js`. To be entirely honest I'm not sure why this worked but it seems that after significant testing it is definitely fixed.

## Testing

<!-- How did you confirm your changes? -->
Created four entries, edited and closed with/without saving in differing orders. Each time I clicked the "..." button, the same four entries remained, and saved changes were kept. 

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->
Run the program, create four entries on any given day, and open and close the modal without saving as many times as desired, and note that the entries have not duplicated. 
